### PR TITLE
Raise an error if the config is an empty dict

### DIFF
--- a/mag/config.py
+++ b/mag/config.py
@@ -32,6 +32,9 @@ class Config:
     def from_dict(cls, config):
         """Recursively create Config instance from dictionary"""
 
+        if len(config) == 0:
+            raise ValueError("Config is empty")
+
         _config = cls()
 
         for name, attr in config.items():

--- a/mag/experiment.py
+++ b/mag/experiment.py
@@ -47,8 +47,8 @@ class Experiment:
                 self.config = config
             else:
                 raise ValueError(
-                    "`config` should be either a path to JSON file "
-                    "a dictonary or an instance of mag.config.Config"
+                    "`config` should be either a path to JSON file, "
+                    "a dictonary, or an instance of mag.config.Config"
                 )
 
             if os.path.isdir(self.experiment_dir):


### PR DESCRIPTION
Hi,

As for now, if the provided configurtion dict is empty, a exception 'Experiment with identifier  already exists.' is raised:
```
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/home/aromanov/.pycharm_helpers/pydev/_pydev_bundle/pydev_umd.py", line 197, in runfile
    pydev_imports.execfile(filename, global_vars, local_vars)  # execute the script
  File "/home/aromanov/.pycharm_helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/home/aromanov/projects/bias_v2/train.py", line 20, in <module>
    main(cfg)
  File "/home/aromanov/projects/bias_v2/train.py", line 13, in main
    with Experiment(cfg, experiments_dir=EXPERIMENTS_DIR) as experiment:
  File "/home/aromanov/software/mag_jgc128/mag/experiment.py", line 62, in __init__
    directory=self.config.identifier
ValueError: Experiment with identifier  already exists. Set `resume_from` to the corresponding identifier (directory name)  or delete it manually and then rerun the code.
```

This is rather confusing and the experiment's identifier is an empty string.

This pull requests raises an error if the provided dictionary is empty:
```
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "/home/aromanov/.pycharm_helpers/pydev/_pydev_bundle/pydev_umd.py", line 197, in runfile
    pydev_imports.execfile(filename, global_vars, local_vars)  # execute the script
  File "/home/aromanov/.pycharm_helpers/pydev/_pydev_imps/_pydev_execfile.py", line 18, in execfile
    exec(compile(contents+"\n", file, 'exec'), glob, loc)
  File "/home/aromanov/projects/bias_v2/train.py", line 20, in <module>
    main(cfg)
  File "/home/aromanov/projects/bias_v2/train.py", line 13, in main
    with Experiment(cfg, experiments_dir=EXPERIMENTS_DIR) as experiment:
  File "/home/aromanov/software/mag_jgc128/mag/experiment.py", line 45, in __init__
    self.config = Config.from_dict(config)
  File "/home/aromanov/software/mag_jgc128/mag/config.py", line 36, in from_dict
    raise ValueError("Config is empty")
ValueError: Config is empty
```



