### PR TITLE
Add egg-info to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .cache
 __pycache__
 
+*.egg-info/
 env/
 
 .vscode


### PR DESCRIPTION
Hi,

`pip install -e .` creates a `mag.egg-info` dir which was not included to `.gitignore`. This pull request fixes it.